### PR TITLE
Add option to regenerate all island labels

### DIFF
--- a/io_export_paper_model.py
+++ b/io_export_paper_model.py
@@ -222,7 +222,7 @@ class Unfolder:
             rd.bake_type = 'TEXTURE' if properties.output_type == 'TEXTURE' else 'FULL'
             rd.use_bake_selected_to_active = (properties.output_type == 'SELECTED_TO_ACTIVE')
 
-            rd.bake_margin, rd.bake_distance, rd.bake_bias, rd.use_bake_to_vertex_color, rd.use_bake_clear = 10, 0, 0.001, False, False
+            rd.bake_margin, rd.bake_distance, rd.bake_bias, rd.use_bake_to_vertex_color, rd.use_bake_clear = 0, 0, 0.001, False, False
             if properties.image_packing == 'PAGE_LINK':
                 self.mesh.save_image(tex, printable_size * ppm, filepath)
             elif properties.image_packing == 'ISLAND_LINK':

--- a/io_export_paper_model.py
+++ b/io_export_paper_model.py
@@ -222,7 +222,7 @@ class Unfolder:
             rd.bake_type = 'TEXTURE' if properties.output_type == 'TEXTURE' else 'FULL'
             rd.use_bake_selected_to_active = (properties.output_type == 'SELECTED_TO_ACTIVE')
 
-            rd.bake_margin, rd.bake_distance, rd.bake_bias, rd.use_bake_to_vertex_color, rd.use_bake_clear = 0, 0, 0.001, False, False
+            rd.bake_margin, rd.bake_distance, rd.bake_bias, rd.use_bake_to_vertex_color, rd.use_bake_clear = 10, 0, 0.001, False, False
             if properties.image_packing == 'PAGE_LINK':
                 self.mesh.save_image(tex, printable_size * ppm, filepath)
             elif properties.image_packing == 'ISLAND_LINK':
@@ -1091,11 +1091,20 @@ class Island:
 
     def generate_label(self, label=None, abbreviation=None):
         """Assign a name to this island automatically"""
+        settings = bpy.context.scene.paper_model
         abbr = abbreviation or self.abbreviation or str(self.number)
+        print(self.label)
         # TODO: dots should be added in the last instant when outputting any text
         if is_upsidedown_wrong(abbr):
             abbr += "."
-        self.label = label or self.label or "Island {}".format(self.number)
+
+        if settings.regenerate_island_labels:
+            # Generate new labels
+            self.label = "Island {}".format(self.number)
+        else:
+            # Use existing labels where possible, otherwise generate new label
+            self.label = label or self.label or "Island {}".format(self.number)
+
         self.abbreviation = abbr
 
     def save_uv(self, tex, cage_size):
@@ -1625,12 +1634,15 @@ class Unfold(bpy.types.Operator):
         priority_effect = {'CONVEX': self.priority_effect_convex, 'CONCAVE': self.priority_effect_concave, 'LENGTH': self.priority_effect_length}
         unfolder = Unfolder(self.object)
         unfolder.prepare(cage_size, self.do_create_uvmap, mark_seams=True, priority_effect=priority_effect, scale=sce.unit_settings.scale_length/settings.scale)
-        if mesh.paper_island_list:
+
+        if mesh.paper_island_list and not settings.regenerate_island_labels:
+            # Use existing labels if not explicitly asking to regenerate them
             unfolder.copy_island_names(mesh.paper_island_list)
 
         island_list = mesh.paper_island_list
         island_list.clear()  # remove previously defined islands
         for island in unfolder.mesh.islands:
+            print(island.label)
             # add islands to UI list and set default descriptions
             list_item = island_list.add()
             # add faces' IDs to the island
@@ -2035,6 +2047,7 @@ class VIEW3D_PT_paper_model_tools(bpy.types.Panel):
         sub.active = sce.paper_model.limit_by_page
         sub.prop(sce.paper_model, "output_size_x")
         sub.prop(sce.paper_model, "output_size_y")
+        col.prop(sce.paper_model, "regenerate_island_labels")
 
 
 class VIEW3D_PT_paper_model_islands(bpy.types.Panel):
@@ -2167,6 +2180,8 @@ class PaperModelSettings(bpy.types.PropertyGroup):
     scale = bpy.props.FloatProperty(name="Scale",
         description="Divisor of all dimensions when exporting",
         default=1, soft_min=1.0, soft_max=10000.0, subtype='UNSIGNED', precision=0)
+    regenerate_island_labels = bpy.props.BoolProperty(name="Regenerate island labels",
+        description="Discard existing island labels and generate new unique labels for all islands", default=False)
 bpy.utils.register_class(PaperModelSettings)
 
 


### PR DESCRIPTION
New option for discarding all existing island labels and regenerating unique island labels. Option is disabled by default. Closes #41.

![screenshot from 2016-06-04 13 57 33](https://cloud.githubusercontent.com/assets/2399255/15799430/81004732-2a5c-11e6-849e-48f26ddf855b.png)
