### PR TITLE
Clip to deal with rounding errors before asin

### DIFF
--- a/io_export_paper_model.py
+++ b/io_export_paper_model.py
@@ -703,7 +703,9 @@ class Edge:
         if not normal_a or not normal_b:
             self.angle = -3  # just a very sharp angle
         else:
-            self.angle = asin(normal_a.cross(normal_b).dot(self.vector.normalized()))
+            s = normal_a.cross(normal_b).dot(self.vector.normalized())
+            s = max(min(s, 1.0), -1.0) # deal with rounding errors
+            self.angle = asin(s)
             if loop_a.link_loop_next.vert != loop_b.vert or loop_b.link_loop_next.vert != loop_a.vert:
                 self.angle = abs(self.angle)
 


### PR DESCRIPTION
This fixes #69, that is due to rounding errors that make values slightly bigger than 1.0 or slightly smaller than -1.0 to be passed to `asin`. Here the values are clipped to the [-1.0, 1.0] interval.