### PR TITLE
Change comparison of angle_epsilon

### DIFF
--- a/pdf.py
+++ b/pdf.py
@@ -185,7 +185,7 @@ class Pdf(Exporter):
                         data_freestyle.append(data_uvedge)
                     # each uvedge exists in two opposite-oriented variants; we want to add each only once
                     if uvedge.sticker or uvedge.uvface.flipped != (id(uvedge.va) > id(uvedge.vb)):
-                        if abs(edge.angle) > self.angle_epsilon:
+                        if abs(edge.angle) >= self.angle_epsilon:
                             edge_group = data_convex if edge.is_convex() else data_concave
                             edge_group.append(data_uvedge)
                 if island.is_inside_out:

--- a/svg.py
+++ b/svg.py
@@ -165,7 +165,7 @@ class Svg(Exporter):
                         vertex_pair = frozenset((uvedge.va, uvedge.vb))
                         if vertex_pair not in visited_edges:
                             visited_edges.add(vertex_pair)
-                            if abs(edge.angle) > self.angle_epsilon:
+                            if abs(edge.angle) >= self.angle_epsilon:
                                 edge_group = data_convex if edge.is_convex() else data_concave
                                 edge_group.append(data_uvedge)
                     if island.is_inside_out:


### PR DESCRIPTION
Change comparison FROM > TO >=. This allows edges to be printed even when the surfaces are exactly planar.

This is helpful in my case as I'm using this to generate files for eventual laser cutting. Occasionally, I model a truly planar object with multiple pieces represented as different faces. Setting the comparison to >= lets those edges between planar faces print.

Great plug-in. Thanks for your work on this. 