### PR TITLE
suggested changes from e-mail

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -55,6 +55,7 @@ class PaperAddonPreferences(bpy.types.AddonPreferences):
 
 module_classes = (
     unfold_operator.Unfold,
+    unfold_operator.Pagelayout,
     unfold_operator.ExportPaperModel,
     unfold_operator.ClearAllSeams,
     unfold_operator.SelectIsland,

--- a/pdf.py
+++ b/pdf.py
@@ -113,6 +113,27 @@ class Pdf(Exporter):
             if any(island.embedded_image for island in page.islands):
                 resources["XObject"] = {}
                 resources["ProcSet"].append("ImageC")
+            if self.use_reg:
+                if self.reg_type == "TYPE 1":
+                    commands.append(self.command_reg.format(
+                        rect="{:.6f} {:.6f}".format(self.margin.x*1000,(self.page_size.y-self.margin.y-self.reg_box_size)*1000),
+                        L= self.reg_box_size*1000,
+                        pos1="{:.6f} {:.6f}".format(self.margin.x*1000,(self.margin.y+self.reg_corner_size)*1000),
+                        pos2="{:.6f} {:.6f}".format(self.margin.x*1000,self.margin.y*1000),
+                        pos3="{:.6f} {:.6f}".format((self.margin.x+self.reg_corner_size)*1000,self.margin.y*1000),
+                        pos4="{:.6f} {:.6f}".format((self.page_size.x-self.margin.x-self.reg_corner_size)*1000,(self.page_size.y-self.margin.y)*1000),
+                        pos5="{:.6f} {:.6f}".format((self.page_size.x-self.margin.x)*1000,(self.page_size.y-self.margin.y)*1000),
+                        pos6="{:.6f} {:.6f}".format((self.page_size.x-self.margin.x)*1000,(self.page_size.y-self.margin.y-self.reg_corner_size)*1000)))
+                else:
+                    commands.append(self.command_reg.format(
+                        rect="{:.6f} {:.6f}".format(self.margin.x*1000,(self.margin.y)*1000),
+                        L= self.reg_box_size*1000,
+                        pos1="{:.6f} {:.6f}".format(self.margin.x*1000,(self.page_size.y-self.margin.y-self.reg_corner_size)*1000),
+                        pos2="{:.6f} {:.6f}".format(self.margin.x*1000,(self.page_size.y-self.margin.y)*1000),
+                        pos3="{:.6f} {:.6f}".format((self.margin.x+self.reg_corner_size)*1000,(self.page_size.y-self.margin.y)*1000),
+                        pos4="{:.6f} {:.6f}".format((self.page_size.x-self.margin.x-self.reg_corner_size)*1000,(self.margin.y)*1000),
+                        pos5="{:.6f} {:.6f}".format((self.page_size.x-self.margin.x)*1000,(self.margin.y)*1000),
+                        pos6="{:.6f} {:.6f}".format((self.page_size.x-self.margin.x)*1000,(self.margin.y+self.reg_corner_size)*1000)))
             for island in page.islands:
                 commands.append("q 1 0 0 1 {0.x:.6f} {0.y:.6f} cm".format(1000*(self.margin + island.pos)))
                 if island.embedded_image:
@@ -237,3 +258,4 @@ class Pdf(Exporter):
     command_sticker = "q /F1 {size:.6f} Tf {mat[0][0]:.6f} {mat[1][0]:.6f} {mat[0][1]:.6f} {mat[1][1]:.6f} {pos.x:.6f} {pos.y:.6f} cm BT {align:.6f} 0 Td ({label}) Tj ET Q"
     command_arrow = "q /F1 {size:.6f} Tf BT {pos.x:.6f} {pos.y:.6f} Td ({index}) Tj ET {mat[0][0]:.6f} {mat[1][0]:.6f} {mat[0][1]:.6f} {mat[1][1]:.6f} {arrow_pos.x:.6f} {arrow_pos.y:.6f} cm 0 0 m 1 -1 l 0 -0.25 l -1 -1 l f Q"
     command_number = "q /F1 {size:.6f} Tf {mat[0][0]:.6f} {mat[1][0]:.6f} {mat[0][1]:.6f} {mat[1][1]:.6f} {pos.x:.6f} {pos.y:.6f} cm BT ({label}) Tj ET Q"
+    command_reg = "q 0 0 0 rg {rect} {L:.3f} {L:.3f} re f Q q {pos1} m {pos2} l {pos3} l S Q q {pos4} m {pos5} l {pos6} l S Q"

--- a/svg.py
+++ b/svg.py
@@ -74,6 +74,32 @@ class Svg(Exporter):
                             height=(self.page_size.y - 2 * self.margin.y)*1000,
                             path=path_convert(page.image_path)),
                         file=f)
+                if self.use_reg:
+                    if self.reg_type == "TYPE 1":
+                        print(
+                            self.registration_mark_tag.format(L=self.reg_box_size*1000,
+                                x=self.margin.x*1000,
+                                y=self.margin.y*1000,
+                                pos1="{:.6f} {:.6f}".format(self.margin.x*1000,(self.page_size.y-self.margin.y-self.reg_corner_size)*1000),
+                                pos2="{:.6f} {:.6f}".format(self.margin.x*1000,(self.page_size.y-self.margin.y)*1000),
+                                pos3="{:.6f} {:.6f}".format((self.margin.x+self.reg_corner_size)*1000,(self.page_size.y-self.margin.y)*1000),
+                                pos4="{:.6f} {:.6f}".format((self.page_size.x-self.margin.x-self.reg_corner_size)*1000,self.margin.y*1000),
+                                pos5="{:.6f} {:.6f}".format((self.page_size.x-self.margin.x)*1000,self.margin.y*1000),
+                                pos6="{:.6f} {:.6f}".format((self.page_size.x-self.margin.x)*1000,(self.margin.y+self.reg_corner_size)*1000)),
+                            file=f)
+                    else:
+                        print(
+                            self.registration_mark_tag.format(L=self.reg_box_size*1000,
+                                x=self.margin.x*1000,
+                                y=(self.page_size.y-self.margin.y-self.reg_box_size)*1000,
+                                pos1="{:.6f} {:.6f}".format(self.margin.x*1000,(self.margin.y+self.reg_corner_size)*1000),
+                                pos2="{:.6f} {:.6f}".format(self.margin.x*1000,(self.margin.y)*1000),
+                                pos3="{:.6f} {:.6f}".format((self.margin.x+self.reg_corner_size)*1000,(self.margin.y)*1000),
+                                pos4="{:.6f} {:.6f}".format((self.page_size.x-self.margin.x-self.reg_corner_size)*1000,(self.page_size.y-self.margin.y)*1000),
+                                pos5="{:.6f} {:.6f}".format((self.page_size.x-self.margin.x)*1000,(self.page_size.y-self.margin.y)*1000),
+                                pos6="{:.6f} {:.6f}".format((self.page_size.x-self.margin.x)*1000,(self.page_size.y-self.margin.y-self.reg_corner_size)*1000)),
+                            file=f)
+                
                 if len(page.islands) > 1:
                     print("<g>", file=f)
 
@@ -197,6 +223,8 @@ class Svg(Exporter):
     text_transformed_tag = "<text transform='matrix({mat} {pos})' style='font-size:{size:.2f}'><tspan>{label}</tspan></text>"
     arrow_marker_tag = "<g><path transform='matrix({mat} {arrow_pos})' class='arrow' d='M 0 0 L 1 1 L 0 0.25 L -1 1 Z'/>" \
         "<text transform='translate({pos})' style='font-size:{scale:.2f}'><tspan>{index}</tspan></text></g>"
+    registration_mark_tag = "<g id='reg mark'><rect width='{L:.6f}' height='{L:.6f}' x='{x:.6f}' y='{y:.6f}' fill = 'black' />" \
+        "<path class='reg' d='M {pos1} L {pos2} L {pos3} M {pos4} L {pos5} L {pos6}'/></g>"
 
     svg_base = """<?xml version='1.0' encoding='UTF-8' standalone='no'?>
     <svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' version='1.1'
@@ -214,6 +242,13 @@ class Svg(Exporter):
         stroke-dasharray: {outer_style};
         stroke-dashoffset: 0;
         stroke-width: {outer_width:.2};
+        stroke-opacity: {outer_alpha:.2};
+    }}
+    path.reg {{
+        stroke: {outer_color};
+        stroke-dasharray: {outer_style};
+        stroke-dashoffset: 0;
+        stroke-width: 0.5;
         stroke-opacity: {outer_alpha:.2};
     }}
     path.convex {{

--- a/unfold_operator.py
+++ b/unfold_operator.py
@@ -6,7 +6,8 @@ import bpy
 import bmesh
 from mathutils import Vector
 
-from .unfolder import Unfolder, UnfoldError, default_priority_effect
+from .unfolder import PageLayoutGrid, Unfolder, UnfoldError, default_priority_effect, is_upsidedown_wrong
+from .nesting import Page
 from .svg import Svg
 from .pdf import Pdf
 from .json import Json
@@ -28,6 +29,110 @@ def first_letters(text):
 first_letters.pattern = re_compile("((?<!\w)\w)|\d")
 
 
+class Pagelayout(bpy.types.Operator):
+    """Blender Operator: make plane as grid."""
+
+    bl_idname = "mesh.pagelayout"
+    bl_label = "Pagelayout"
+    bl_description = "place and unfold grid to have it as referance"
+    bl_options = {'REGISTER', 'UNDO'}
+    edit: bpy.props.BoolProperty(default=False, options={'HIDDEN'})
+    priority_effect_convex: bpy.props.FloatProperty(
+        name="Priority Convex", description="Priority effect for edges in convex angles",
+        default=default_priority_effect['CONVEX'], soft_min=-1, soft_max=10, subtype='FACTOR')
+    priority_effect_concave: bpy.props.FloatProperty(
+        name="Priority Concave", description="Priority effect for edges in concave angles",
+        default=default_priority_effect['CONCAVE'], soft_min=-1, soft_max=10, subtype='FACTOR')
+    priority_effect_length: bpy.props.FloatProperty(
+        name="Priority Length", description="Priority effect of edge length",
+        default=default_priority_effect['LENGTH'], soft_min=-10, soft_max=1, subtype='FACTOR')
+
+    @classmethod
+    def poll(cls, context):
+        return context.active_object and context.active_object.type == "MESH" and context.active_object.name != 'pagelayoutgrid'
+
+    def draw(self, context):
+        layout = self.layout
+        col = layout.column()
+        layout.label(text="Edge Cutting Factors:")
+        col = layout.column(align=True)
+        col.label(text="Face Angle:")
+        col.prop(self.properties, "priority_effect_convex", text="Convex")
+        col.prop(self.properties, "priority_effect_concave", text="Concave")
+        layout.prop(self.properties, "priority_effect_length", text="Edge Length")
+
+    def execute(self, context):
+        sce = bpy.context.scene
+        settings = sce.paper_model
+        recall_mode = context.object.mode
+        if bpy.context.mode == 'EDIT_MESH':
+            bpy.ops.object.mode_set(mode='OBJECT')
+
+        grid = PageLayoutGrid(settings.output_size_x, settings.output_size_y, settings.output_margin,settings.page_count)
+        grid.object.select_set(True)
+        #grid.object.data.uv_layers.active = grid.data.object.uv_layers['Unfolded']
+        bpy.ops.object.mode_set(mode='EDIT')
+
+        pagesize = Vector((settings.output_size_x,settings.output_size_y))
+        printable_size = pagesize - 2*settings.output_margin*Vector((1,1))
+
+        priority_effect = {
+            'CONVEX': self.priority_effect_convex,
+            'CONCAVE': self.priority_effect_concave,
+            'LENGTH': self.priority_effect_length}
+        try:
+            unfolder = Unfolder(grid.object) 
+            unfolder.mesh.generate_cuts(grid.size+Vector((0.1,0.1)), priority_effect)
+            unfolder.mesh.islands.sort(key = lambda island: list(island.faces.keys())[0].index)
+            for i,island in enumerate(unfolder.mesh.islands,1):
+                abbr = str(i)
+                points = [point.co for point in island.vertices.values()]
+                bottom_left = Vector((min(v.x for v in points),min(v.y for v in points)))
+                for point in points:
+                    point -= bottom_left
+                island.bounding_box = Vector((max(v.x for v in points),max(v.y for v in points)))
+        # TODO: dots should be added in the last instant when outputting any text
+                if is_upsidedown_wrong(abbr):
+                    abbr += "."
+                island.label = "Page {}".format(i)
+                island.abbreviation = abbr
+                page = Page(i)
+                page.islands.append(island)
+                unfolder.mesh.pages.append(page)
+            unfolder.mesh.save_uv(printable_size,False,settings.page_count)
+            unfolder.mesh.mark_cuts()
+            
+        except UnfoldError as error:
+            self.report(type={'ERROR_INVALID_INPUT'}, message=error.args[0])
+            error.mesh_select()
+            bpy.ops.object.mode_set(mode=recall_mode)
+            return {'CANCELLED'}
+        mesh = grid.object.data
+        mesh.update()
+        if mesh.paper_island_list:
+            unfolder.copy_island_names(mesh.paper_island_list)
+        island_list = mesh.paper_island_list
+        attributes = {item.label: (item.abbreviation, item.auto_label, item.auto_abbrev) for item in island_list}
+        island_list.clear()  # remove previously defined islands
+        for island in unfolder.mesh.islands:
+            # add islands to UI list and set default descriptions
+            list_item = island_list.add()
+            # add faces' IDs to the island
+            for face in island.faces:
+                lface = list_item.faces.add()
+                lface.id = face.index
+            list_item["label"] = island.label
+            list_item["abbreviation"], list_item["auto_label"], list_item["auto_abbrev"] = attributes.get(
+                island.label,
+                (island.abbreviation, False, False))
+            island_item_changed(list_item, context)
+            mesh.paper_island_index = -1
+
+        del unfolder
+        bpy.ops.object.mode_set(mode=recall_mode)
+        return {'FINISHED'}
+
+
 class Unfold(bpy.types.Operator):
     """Blender Operator: unfold the selected object."""
 
@@ -46,7 +151,7 @@ class Unfold(bpy.types.Operator):
         name="Priority Length", description="Priority effect of edge length",
         default=default_priority_effect['LENGTH'], soft_min=-10, soft_max=1, subtype='FACTOR')
     do_create_uvmap: bpy.props.BoolProperty(
-        name="Create UVMap", description="Create a new UV Map showing the islands and page layout", default=False)
+        name="Create UVMap", description="Create a new UV Map showing the islands and page layout", default=True)
     object = None
 
     @classmethod
@@ -82,7 +187,7 @@ class Unfold(bpy.types.Operator):
             unfolder = Unfolder(self.object)
             unfolder.do_create_uvmap = self.do_create_uvmap
             scale = sce.unit_settings.scale_length / settings.scale
-            unfolder.prepare(cage_size, priority_effect, scale, settings.limit_by_page)
+            unfolder.prepare(cage_size, priority_effect, scale, settings.limit_by_page, call=True, text_size=settings.sticker_width)
             unfolder.mesh.mark_cuts()
         except UnfoldError as error:
             self.report(type={'ERROR_INVALID_INPUT'}, message=error.args[0])
@@ -140,8 +245,8 @@ class ClearAllSeams(bpy.types.Operator):
 
 def page_size_preset_changed(self, context):
     """Update the actual document size to correct values"""
-    if hasattr(self, "limit_by_page") and not self.limit_by_page:
-        return
+    # if hasattr(self, "limit_by_page") and not self.limit_by_page:
+    #     return
     if self.page_size_preset == 'A4':
         self.output_size_x = 0.210
         self.output_size_y = 0.297
@@ -290,6 +395,12 @@ class ExportPaperModel(bpy.types.Operator):
     sticker_width: bpy.props.FloatProperty(
         name="Tabs and Text Size", description="Width of gluing tabs and numbers",
         default=0.005, min=0, soft_max=0.05, step=0.01, subtype="UNSIGNED", unit="LENGTH")
+    reg_box_size: bpy.props.FloatProperty(
+        name="box Size", description="size of the black squre",
+        default=0.006, soft_min=0, soft_max=0.05, step=0.1, subtype="UNSIGNED", unit="LENGTH")
+    reg_corner_size: bpy.props.FloatProperty(
+        name="corner Size", description="length of the corner edges",
+        default=0.02, soft_min=0, soft_max=0.06, step=0.1, subtype="UNSIGNED", unit="LENGTH")
     paper_thickness: bpy.props.FloatProperty(
         name="Paper Thickness", description="Compensate for thick material before gluing tabs",
         default=0.000, min=0, soft_max=0.05, step=0.001, subtype="UNSIGNED", unit="LENGTH")
@@ -308,6 +419,12 @@ class ExportPaperModel(bpy.types.Operator):
             ('PDF', "PDF", "Adobe Portable Document Format 1.4"),
             ('SVG', "SVG", "W3C Scalable Vector Graphics"),
             ('JSON', 'JSON', 'JavaScript Object Notation'),
+        ])
+    reg_type: bpy.props.EnumProperty(
+        name="Reg. Marks Type", description="Cameo registration marks compatible",
+        default='TYPE 1', items=[
+            ('TYPE 1', "Type 1", "Box at top left corner"),
+            ('TYPE 2', "Inverted", "Box at bottom left corner"),
         ])
     image_packing: bpy.props.EnumProperty(
         name="Image Packing Method", description="Method of attaching baked image(s) to the SVG",
@@ -328,11 +445,23 @@ class ExportPaperModel(bpy.types.Operator):
     do_create_uvmap: bpy.props.BoolProperty(
         name="Create UVMap",
         description="Create a new UV Map showing the islands and page layout",
+        default=True, options={'SKIP_SAVE'})
+    use_reg: bpy.props.BoolProperty(
+        name="Create Reg. marks",
+        description="Create Reg. matks on the page for cameo machine",
+        default=False, options={'SKIP_SAVE'})
+    use_mat_color: bpy.props.BoolProperty(
+        name="Use Materials Color",
+        description="Use the materials(Principled BSDF) base color as fill layer",
         default=False, options={'SKIP_SAVE'})
     ui_expanded_document: bpy.props.BoolProperty(
         name="Show Document Settings Expanded",
         description="Shows the box 'Document Settings' expanded in user interface",
         default=True, options={'SKIP_SAVE'})
+    ui_expanded_reg: bpy.props.BoolProperty(
+        name="Show Reg. Settings Expanded",
+        description="Shows the box 'Reg settings' expanded in user interface",
+        default=False, options={'SKIP_SAVE'})
     ui_expanded_style: bpy.props.BoolProperty(
         name="Show Style Settings Expanded",
         description="Shows the box 'Colors and Style' expanded in user interface",
@@ -358,7 +487,8 @@ class ExportPaperModel(bpy.types.Operator):
         self.unfolder = Unfolder(self.object)
         cage_size = Vector((sce.paper_model.output_size_x, sce.paper_model.output_size_y))
         unfolder_scale = sce.unit_settings.scale_length/self.scale
-        self.unfolder.prepare(cage_size, scale=unfolder_scale, limit_by_page=sce.paper_model.limit_by_page)
+        m_call = not bpy.context.active_object.data.paper_island_list
+        self.unfolder.prepare(cage_size, scale=unfolder_scale, limit_by_page=sce.paper_model.limit_by_page, call=m_call, text_size=sce.paper_model.sticker_width)
         if sce.paper_model.use_auto_scale:
             self.scale = ceil(self.get_scale_ratio(sce))
 
@@ -439,6 +569,7 @@ class ExportPaperModel(bpy.types.Operator):
             col.prop(self.properties, "output_size_y")
             box.prop(self.properties, "output_margin")
             col = box.column()
+            col.prop(self.properties, "use_mat_color")
             col.prop(self.properties, "tab_style")
             col.prop(self.properties, "number_style")
             col = box.column()
@@ -463,6 +594,18 @@ class ExportPaperModel(bpy.types.Operator):
             row = col.row()
             row.active = self.file_format == 'SVG'
             row.prop(self.properties, "image_packing", text="Images")
+
+        box = layout.box()
+        row = box.row(align=True)
+        row.prop(
+            self.properties, "ui_expanded_reg", text="",
+            icon=('TRIA_DOWN' if self.ui_expanded_reg else 'TRIA_RIGHT'), emboss=False)
+        row.label(text="REG Settings")
+        if self.ui_expanded_reg:
+            box.prop(self.properties, "use_reg")
+            box.prop(self.properties, "reg_type", text="Type")
+            box.prop(self.properties,"reg_box_size")
+            box.prop(self.properties,"reg_corner_size")
 
         box = layout.box()
         row = box.row(align=True)
@@ -592,7 +735,8 @@ class VIEW3D_PT_paper_model_tools(bpy.types.Panel):
         sce = context.scene
         obj = context.active_object
         mesh = obj.data if obj and obj.type == 'MESH' else None
-
+        props = sce.paper_model
+        layout.column().prop(props,"page_count")
         layout.operator("mesh.unfold")
 
         if context.mode == 'EDIT_MESH':
@@ -601,6 +745,7 @@ class VIEW3D_PT_paper_model_tools(bpy.types.Panel):
             row.operator("mesh.mark_seam", text="Clear Seam").clear = True
         else:
             layout.operator("mesh.clear_all_seams")
+        layout.operator("mesh.pagelayout", text="Grid")
 
 
 class VIEW3D_PT_paper_model_settings(bpy.types.Panel):
@@ -750,6 +895,15 @@ class PaperModelSettings(bpy.types.PropertyGroup):
     output_size_y: bpy.props.FloatProperty(
         name="Height", description="Maximal height of an island",
         default=0.29, soft_min=0.148, soft_max=1.189, subtype="UNSIGNED", unit="LENGTH")
+    sticker_width: bpy.props.FloatProperty(
+        name="Tabs and Text Size", description="Width of gluing tabs and their numbers",
+        default=0.005, soft_min=0, soft_max=0.05, step=0.1, subtype="UNSIGNED", unit="LENGTH")
+    output_margin: bpy.props.FloatProperty(
+        name="Page Margin", description="Distance from page borders to the printable area",
+        default=0.005, min=0, soft_max=0.1, step=0.1, subtype="UNSIGNED", unit="LENGTH")
+    page_count: bpy.props.IntProperty(
+        name="page count", description="number of pages x^2",
+        default=3, min=3, soft_max=9, step=1, subtype="UNSIGNED")
     use_auto_scale: bpy.props.BoolProperty(
         name="Automatic Scale", description="Scale the net automatically to fit on paper",
         default=True)

--- a/unfolder.py
+++ b/unfolder.py
@@ -11,7 +11,7 @@ import bmesh
 from mathutils import Matrix, Vector
 from mathutils.geometry import convex_hull_2d
 
-from .nesting import get_nester
+from .nesting import Page, get_nester
 
 default_priority_effect = {
     'CONVEX': 0.5,
@@ -145,6 +145,29 @@ def apply_rna_properties(memory, *datablocks):
             setattr(data, key, value)
 
 
+class PageLayoutGrid:
+    def __init__(self,size_x,size_y,margin,count):
+        x=count*(size_x-2*margin)
+        y=count*(size_y-2*margin)
+        self.size = Vector((x,y))
+        scale_x = Matrix.Scale(x,4,(1.0,0,0))
+        scale_y = Matrix.Scale(y,4,(0,1.0,0))
+        pos = Matrix.Translation((x/2,y/2,0))
+        for obj in bpy.data.objects:
+            if "pagelayoutgrid" in obj.name:
+                bpy.data.meshes.remove(obj.data)
+
+        me = bpy.data.meshes.new("griddata")
+        bm = bmesh.new()
+        bmesh.ops.create_grid(bm, x_segments = count, y_segments = count, size= 0.5, matrix = pos@scale_x@scale_y, calc_uvs=True)
+        for edge in bm.edges:
+            edge.seam = True
+        bm.to_mesh(me)
+        bm.free()
+        self.object = bpy.data.objects.new("pagelayoutgrid", me)
+        bpy.context.collection.objects.link(self.object)
+
+
 class UnfoldError(ValueError):
     def mesh_select(self):
         if len(self.args) >= 3:
@@ -162,7 +185,7 @@ class UnfoldError(ValueError):
 
 class Unfolder:
     def __init__(self, ob):
-        self.do_create_uvmap = False
+        self.do_create_uvmap = True
         bm = bmesh.from_edit_mesh(ob.data)
         self.mesh = Mesh(bm, ob.matrix_world)
         # api bug workaround to make mesh.save_uv work correctly
@@ -173,13 +196,19 @@ class Unfolder:
         if not self.do_create_uvmap:
             self.mesh.delete_uvmap()
 
-    def prepare(self, cage_size=None, priority_effect=default_priority_effect, scale=1, limit_by_page=False):
+    def prepare(self, cage_size=None, priority_effect=default_priority_effect, scale=1, limit_by_page=False, call= True, text_size = 0.005):
         """Create the islands of the net"""
+        settings = bpy.context.scene.paper_model
+        printable_size = cage_size - 2 * settings.output_margin * Vector((1, 1))
         self.mesh.check_correct()
         self.mesh.generate_cuts(cage_size / scale if limit_by_page and cage_size else None, priority_effect)
-        self.mesh.finalize_islands(cage_size or Vector((1, 1)))
+        self.mesh.generate_stickers(text_size, True)
+        self.mesh.finalize_islands(printable_size, title_height=text_size*1.2, method=False)
+        self.mesh.clear_marker()
         self.mesh.enumerate_islands()
-        self.mesh.save_uv()
+        if call:
+            self.mesh.pages = paginate_islands(self.mesh.islands, printable_size)
+            self.mesh.save_uv(printable_size, False, settings.page_count)
 
     def copy_island_names(self, island_list):
         """Copy island label and abbreviation from the best matching island in the list"""
@@ -212,6 +241,7 @@ class Unfolder:
         unit_scale = bpy.context.scene.unit_settings.scale_length
         ppm = properties.output_dpi * 100 / 2.54  # pixels per meter
 
+        self.mesh.uv_pos_read(printable_size)
         # after this call, all dimensions will be in meters
         self.mesh.scale_islands(unit_scale/properties.scale)
         if properties.tab_style == 'STICKER':
@@ -221,8 +251,7 @@ class Unfolder:
 
         text_height = properties.sticker_width if (properties.number_style != 'NONE' and len(self.mesh.islands) > 1) else 0
         # title height must be somewhat larger that text size, glyphs go below the baseline
-        self.mesh.finalize_islands(printable_size, title_height=text_height * 1.2)
-        self.mesh.pages = paginate_islands(self.mesh.islands, printable_size, properties.nesting_method)
+        self.mesh.finalize_islands(printable_size, title_height=text_height * 1.2, method=True)
 
         if properties.texture_type != 'NONE':
             # bake an image and save it as a PNG to disk or into memory
@@ -269,7 +298,12 @@ class Mesh:
     def __init__(self, bm, matrix):
         self.data = bm
         self.matrix = matrix.to_3x3()
-        self.looptex = bm.loops.layers.uv.new("Unfolded")
+        self.looptex = bm.loops.layers.uv.get("Unfolded")
+        if not self.looptex:
+            self.looptex = bm.loops.layers.uv.new("Unfolded")
+        self.looptex1 = bm.loops.layers.uv.get("exportuv")
+        if not self.looptex1:
+            self.looptex1 = bm.loops.layers.uv.new("exportuv")
         edge_layers = bm.edges.layers.bool
         freestyle_layer = edge_layers.get("freestyle_edge")
         self.edges = {bmedge: Edge(bmedge, freestyle_layer) for bmedge in bm.edges}
@@ -412,6 +446,52 @@ class Mesh:
                     right.neighbor_left = left
         return True
 
+    def uv_pos_read(self,cage_size):
+        x_co = y_co = page_index = 0
+        ob = bpy.context.active_object
+        bm = bmesh.from_edit_mesh(ob.data)
+        looptexture = bm.loops.layers.uv['Unfolded']
+        if len(self.pages) == 0:
+            page = Page(1)
+            for island in self.islands:
+                page.islands.append(island)
+            self.pages.append(page)
+        for island in self.islands:
+            loop = list(island.vertices.keys())[0]
+            x, y = loop[looptexture].uv.x, loop[looptexture].uv.y
+            for a in range(5):
+                if cage_size.x * a <= x <= (cage_size.x*(a+1)):
+                    x_co = a
+            for b in range(5):
+                if cage_size.y * b <= y <= (cage_size.y*(b+1)):
+                    y_co = b
+            page_index = x_co + (y_co*5)
+            for loop, uvvertex in island.vertices.items():
+                uvvertex.co.x = loop[looptexture].uv.x - (x_co*cage_size.x)
+                uvvertex.co.y = loop[looptexture].uv.y - (y_co*cage_size.y)
+            if page_index >= len(self.pages):
+                max = len(self.pages)
+                dif = page_index - (max-1)
+                for i in range(dif):
+                    page = Page(max+i+1)
+                    self.pages.append(page)
+            for index, page in enumerate(self.pages):
+                for island_b in page.islands:
+                    if island_b is island and index != page_index:
+                        if x_co < 0 or y_co < 0 or page_index < 0:
+                            self.pages[index].islands.remove(island)
+                        else:
+                            self.pages[page_index].islands.append(island)
+                            self.pages[index].islands.remove(island)
+        self.pages = [page for page in self.pages if page.islands]
+
+    def clear_marker(self):
+        for island in self.islands:
+            island.fake_vertices.clear()
+            island.markers.clear()
+            for uvedge in island.boundary:
+                uvedge.sticker = None
+
     def generate_stickers(self, default_width, number_style, paper_thickness=0.0):
         """Add sticker faces where they are needed."""
         def uvedge_priority(uvedge):
@@ -505,18 +585,21 @@ class Mesh:
             for point in chain((vertex.co for vertex in vertices), island.fake_vertices):
                 point *= scale
 
-    def finalize_islands(self, cage_size, title_height=0):
+    def finalize_islands(self, cage_size, title_height=0, method=True):
         for island in self.islands:
             if title_height:
                 island.title = "[{}] {}".format(island.abbreviation, island.label)
             points = [vertex.co for vertex in set(island.vertices.values())] + island.fake_vertices
-            _, sinx, cosx = cage_fit(points, (cage_size.y - title_height) / cage_size.x)
-            rot = rotation_matrix(sinx, cosx)
-            for point in points:
-                point.rotate(rot)
-            for marker in island.markers:
-                marker.rot = rot @ marker.rot
+            if not method:
+                _, sinx, cosx = cage_fit(points, (cage_size.y - title_height) / cage_size.x)
+                rot = rotation_matrix(sinx, cosx)
+                for point in points:
+                    point.rotate(rot)
+                for marker in island.markers:
+                    marker.rot = rot @ marker.rot
             bottom_left = Vector((min(v.x for v in points), min(v.y for v in points) - title_height))
+            if method:
+                island.pos = bottom_left
             # DEBUG
             # top_right = Vector((max(v.x for v in points), max(v.y for v in points) - title_height))
             # print(f"fitted aspect: {(top_right.y - bottom_left.y) / (top_right.x - bottom_left.x)}")
@@ -527,13 +610,21 @@ class Mesh:
     def largest_island_ratio(self, cage_size):
         return max(i / p for island in self.islands for (i, p) in zip(island.bounding_box, cage_size))
 
-    def save_uv(self, cage_size=Vector((1, 1)), separate_image=False):
+    def save_uv(self, cage_size=Vector((1, 1)), separate_image=False, x=3):
         if separate_image:
             for island in self.islands:
-                island.save_uv_separate(self.looptex)
+                island.save_uv_separate(self.looptex1)
         else:
-            for island in self.islands:
-                island.save_uv(self.looptex, cage_size)
+            x_shift = y_shift = 0
+            for number, page in enumerate(self.pages):
+                x_shift = number % x
+                for island in page.islands:
+                    cor_pos = Vector((island.pos.x + (cage_size.x * x_shift),island.pos.y + (cage_size.y * y_shift)))
+                    for loop, uvvertex in island.vertices.items():
+                        uv = uvvertex.co + cor_pos
+                        loop[self.looptex].uv = uv
+                if x_shift % (x-1) == 0 and x_shift !=0:
+                    y_shift += 1
 
     def save_image(self, page_size_pixels: Vector, filename):
         for page in self.pages:
@@ -566,7 +657,7 @@ class Mesh:
     def bake(self, faces, image):
         # FIXME: as of 3.5.0, this detection does not work properly
         # and one of existing 8 UVLayers would be overwritten
-        if not self.looptex:
+        if not self.looptex1:
             raise UnfoldError("The mesh has no UV Map slots left. Either delete a UV Map or export the net without textures.")
         ob = bpy.context.active_object
         me = ob.data
@@ -686,7 +777,7 @@ class Island:
         'image_path', 'embedded_image',
         'label', 'abbreviation', 'title',
         'has_safe_geometry', 'is_inside_out',
-        'sticker_numbering')
+        'sticker_numbering', 'mat_index', 'isl_color')
 
     def __init__(self, mesh, face, matrix, normal_matrix):
         """Create an Island from a single Face"""
@@ -710,8 +801,14 @@ class Island:
         self.vertices.update(uvface.vertices)
         self.edges.update(uvface.edges)
         self.faces[face] = uvface
+        self.mat_index = face.material_index
         # UVEdges on the boundary
         self.boundary = list(self.edges.values())
+        object = bpy.context.active_object.data
+        if object.materials: 
+            self.isl_color=object.materials[self.mat_index].node_tree.nodes['Principled BSDF'].inputs[0].default_value
+        else:
+            self.isl_color=[1,1,1,1]
 
     def add_marker(self, marker):
         self.fake_vertices.extend(marker.bounds)
@@ -1250,3 +1347,8 @@ class Exporter:
         self.pure_net = (properties.texture_type == 'NONE')
         self.text_size = properties.sticker_width
         self.angle_epsilon = properties.angle_epsilon
+        self.use_mat_color = properties.use_mat_color
+        self.use_reg = properties.use_reg
+        self.reg_type = properties.reg_type
+        self.reg_box_size = properties.reg_box_size
+        self.reg_corner_size = properties.reg_corner_size


### PR DESCRIPTION
I forward-ported the changes from the single-file version of the addon as it has been extended by Mazen Alimam.

> (...) features as follow:
> 1. You can see the arrangement of the islands in the uv editor
> In "Unfolded" map the code checks if the map exists or not and overwrite
> it. This give you the freedom to position ,rotate and align the islands
> using what blender can give you then the export operator read the uv map.
> 2. You can control which edge you want to put sticker on by pinning the
> first vertex of that Edge clockwise.
> 3. I added Grid operator that make a plane object subdivided based on page
> size and margin when you enter edit mode in uv editor it will act ass
> visual representation of the printable size.
> 4. The code export material as texture which make the pdf,svg size bigger
> some time you only want the color of the islands so I added a check box in
> the export window that read that color from the material of every islands
> and add it as a attribute in the pdf or svg which make the file the same as
> pure net but with solid color.
> 5. Added a setup for registration marks in the export window compatible
> with Cameo paper cutter machine.