### PR TITLE
Add a try/except to catch errors which leads to abort of export procss

### DIFF
--- a/unfolder.py
+++ b/unfolder.py
@@ -144,7 +144,7 @@ def apply_rna_properties(memory, *datablocks):
         for key, value in recall.items():
             try:
                 setattr(data, key, value)
-            except:
+            except TypeError:
                 print(f'WARN: cannot restore rna property "{key}" to "{value}"')
 
 

--- a/unfolder.py
+++ b/unfolder.py
@@ -142,7 +142,10 @@ def store_rna_properties(*datablocks):
 def apply_rna_properties(memory, *datablocks):
     for recall, data in zip(memory, datablocks):
         for key, value in recall.items():
-            setattr(data, key, value)
+            try:
+                setattr(data, key, value)
+            except:
+                print(f'WARN: cannot restore rna property "{key}" to "{value}"')
 
 
 class UnfoldError(ValueError):


### PR DESCRIPTION
In my installation (Blender 4.3.2 on debian trixie) there occurs an excpetion when exporting the paper modell using textures.

The console shows a warning 

    WARN (bpy.rna): ./source/blender/python/intern/bpy_rna.cc:1367 pyrna_enum_to_py: current value '4' matches no enum in 'CyclesRenderSettings', '', 'denoiser'

This warning occurs in `store_rna_properties()` , leading to error in `apply_rna_properties()` 

    TypeError: bpy_struct: item.attr = val: enum "" not found in ()

because the empty string value cannot be assinged.
With this error the export gets reproducibly aborted.
I do not know the root cause (maybe document properties), but this fixes the behaviour.