### PR TITLE
Add a option for texture margin

### DIFF
--- a/unfold_operator.py
+++ b/unfold_operator.py
@@ -267,6 +267,9 @@ class ExportPaperModel(bpy.types.Operator):
             ('RENDER', "Full Render", "Render the material in actual scene illumination"),
             ('SELECTED_TO_ACTIVE', "Selected to Active", "Render all selected surrounding objects as a texture")
         ])
+    texture_margin: bpy.props.IntProperty(name="Texture image margin",
+        description="Extend the texture image beyond the edge of the islands to avoid gaps",
+        default=1, soft_min=0, subtype="UNSIGNED")
     output_layers: bpy.props.EnumProperty(
         name="Layers", description="Separation of drawings by meaning",
         default='ONESIDE', items=[
@@ -459,6 +462,8 @@ class ExportPaperModel(bpy.types.Operator):
             row = col.row()
             row.active = self.texture_type in ('AMBIENT_OCCLUSION', 'RENDER', 'SELECTED_TO_ACTIVE')
             row.prop(self.properties, "bake_samples")
+            row = col.row()
+            row.prop(self.properties, "texture_margin", text="Texture margin (px)")
             col.prop(self.properties, "output_dpi")
             row = col.row()
             row.active = self.file_format == 'SVG'

--- a/unfolder.py
+++ b/unfolder.py
@@ -240,7 +240,8 @@ class Unfolder:
             lookup = {'TEXTURE': 'DIFFUSE', 'AMBIENT_OCCLUSION': 'AO', 'RENDER': 'COMBINED', 'SELECTED_TO_ACTIVE': 'COMBINED'}
             sce.cycles.bake_type = lookup[properties.texture_type]
             bk.use_selected_to_active = (properties.texture_type == 'SELECTED_TO_ACTIVE')
-            bk.margin, bk.cage_extrusion, bk.use_cage, bk.use_clear = 1, 10, False, False
+            bk.cage_extrusion, bk.use_cage, bk.use_clear = 10, False, False
+            bk.margin = properties.texture_margin
             if properties.texture_type == 'TEXTURE':
                 bk.use_pass_direct, bk.use_pass_indirect, bk.use_pass_color = False, False, True
                 sce.cycles.samples = 1
@@ -598,7 +599,7 @@ class Mesh:
         try:
             ob.update_from_editmode()
             me.uv_layers.active = me.uv_layers[self.looptex.name]
-            bpy.ops.object.bake(type=bake_type, margin=1, use_selected_to_active=sta, cage_extrusion=100, use_clear=False)
+            bpy.ops.object.bake(type=bake_type, margin=bpy.context.scene.render.bake.margin, use_selected_to_active=sta, cage_extrusion=100, use_clear=False)
         except RuntimeError as e:
             raise UnfoldError(*e.args)
         finally:

--- a/unfolder.py
+++ b/unfolder.py
@@ -599,7 +599,7 @@ class Mesh:
         try:
             ob.update_from_editmode()
             me.uv_layers.active = me.uv_layers[self.looptex.name]
-            bpy.ops.object.bake(type=bake_type, margin=bpy.context.scene.render.bake.margin, use_selected_to_active=sta, cage_extrusion=100, use_clear=False)
+            bpy.ops.object.bake(type=bake_type, use_selected_to_active=sta, cage_extrusion=100, use_clear=False)
         except RuntimeError as e:
             raise UnfoldError(*e.args)
         finally:


### PR DESCRIPTION
Based on #44 I created a more recent version based on the current main branch. 

It allows to extend the texture image by some pixels to compensate some small errors in double sided printing or manual cutting 